### PR TITLE
feat: test mbarrier for sync threads

### DIFF
--- a/Cuda/bar_sync/CMakeLists.txt
+++ b/Cuda/bar_sync/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.25.0)
+project(test_bar_sync LANGUAGES CXX CUDA)
+
+set(TARGET bar_sync)
+
+set(CMAKE_BUILD_TYPE Release)
+
+# Prohibit in-source builds
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source build are not supported")
+endif()
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/../cmake")
+set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/../../third_party/")
+
+set(CMAKE_CXX_STANDARD
+    17
+    CACHE STRING "The C++ standard whose features are requested." FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_CUDA_STANDARD
+    17
+    CACHE STRING "The CUDA standard whose features are requested." FORCE)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+# Set host compiler flags. Enable all warnings and treat them as errors
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
+
+find_package(CUDAToolkit QUIET REQUIRED)
+enable_language(CUDA)
+set(CMAKE_CUDA on)
+
+set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+
+include_directories(${PROJECT_SOURCE_DIR}/..)
+
+set(CUDA_NVCC_FLAGS
+    ${CUDA_NVCC_FLAGS}
+    -std=c++17
+    -Xcompiler
+    -fPIC
+    -rdc=true
+    --extended-lambda
+    --expt-relaxed-constexpr)
+
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
+                    "-gencode arch=compute_100a,code=sm_100a")
+message(STATUS "CUDA_NVCC_FLAGS: ${CUDA_NVCC_FLAGS}")
+
+add_executable(${TARGET} bar_sync.cu ../../curand_fp16.cu)
+set_target_properties(${TARGET} PROPERTIES CUDA_ARCHITECTURES 100a)
+target_link_libraries(${TARGET} PRIVATE CUDA::curand)

--- a/Cuda/bar_sync/bar_sync.cu
+++ b/Cuda/bar_sync/bar_sync.cu
@@ -1,0 +1,178 @@
+#include "barrier.cuh"
+#include "copy.cuh"
+#include "cuda_utils.cuh"
+#include "sync.cuh"
+#include "utils.cuh"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <cstdint>
+#include <iostream>
+
+using namespace copy;
+using namespace barrier;
+namespace {
+
+__device__ __forceinline__ void init_barrier(uint64_t* barrier,
+                                             int arrive_count) {
+  uint32_t barrier_ptr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(barrier));
+  asm volatile(
+      "{\n\t"
+      "mbarrier.init.shared::cta.b64 [%1], %0; \n"
+      "}"
+      :
+      : "r"(arrive_count), "r"(barrier_ptr));
+}
+
+__device__ __forceinline__ void arrive(uint64_t const* barrier) {
+  printf("tid: %d: arrive\n", threadIdx.x);
+  uint32_t barrier_ptr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(barrier));
+  asm volatile(
+      "{\n\t"
+      "mbarrier.arrive.shared::cta.b64 _, [%0];\n\t"  // "_" sink symbol is used
+      "}"
+      :
+      : "r"(barrier_ptr));
+}
+
+__device__ __forceinline__ void wait(uint64_t* barrier, int phase) {
+  printf("tid: %d: wait\n", threadIdx.x);
+  uint32_t barrier_ptr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(barrier));
+  constexpr uint32_t ticks = 0x989680;  // timeout
+  asm volatile(
+      "{\n\t"
+      ".reg .pred       P1; \n\t"  // predicate register
+      "LAB_WAIT: \n\t"             // spin-wait loop
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, %2; \n\t"
+      "@P1 bra DONE; \n\t"
+      "bra     LAB_WAIT; \n\t"
+      "DONE: \n\t"
+      "}"
+      :
+      : "r"(barrier_ptr), "r"(phase), "r"(ticks));
+}
+
+template <const int kNumel>
+__global__ void test_bar_sync(const bfloat16* scores, const bfloat16* bias,
+                              bfloat16* output) {
+  if (blockIdx.x) return;
+
+  using DType = bfloat16;
+  extern __shared__ __align__(1024) uint8_t buf_[];
+  auto sptr_uint = [](auto* ptr) { return __cvta_generic_to_shared(ptr); };
+  int tid = threadIdx.x;
+
+  DType* scores_s = reinterpret_cast<DType*>(buf_);
+  DType* bias_s = scores_s + kNumel;
+  DType* biased_scores_s = bias_s + kNumel;
+
+  // for barrier
+  auto barrier_ptr = reinterpret_cast<uint64_t*>(biased_scores_s + kNumel);
+  if (threadIdx.x == 0) {
+    init_barrier(barrier_ptr, 4);
+  }
+
+  static constexpr int kBytesPerAccess = 128 / 8;
+  static constexpr int kNumPerAccess = kBytesPerAccess / sizeof(DType);
+
+  // step1: load scores and bias to shared memory
+  int num_load_threads = kNumel / kNumPerAccess;
+  int offset = tid * kNumPerAccess;
+  if (tid < num_load_threads) {
+    ld_global_st_shared<kBytesPerAccess>(sptr_uint(scores_s + offset),
+                                         scores + offset);
+    ld_global_st_shared<kBytesPerAccess>(sptr_uint(bias_s + offset),
+                                         bias + offset);
+  }
+  block::copy_async();
+
+  // step2 : add bias to scores using vectorized addition(128 threads)
+  int compute_threads = kNumel / 2;
+
+  if (tid < compute_threads) {
+    bfloat162 v_scores = *reinterpret_cast<bfloat162*>(scores_s + tid * 2);
+    bfloat162 v_bias = *reinterpret_cast<bfloat162*>(bias_s + tid * 2);
+    bfloat162 biased_score = __hadd2(v_scores, v_bias);
+    *reinterpret_cast<bfloat162*>(biased_scores_s + tid * 2) = biased_score;
+
+    if (tid % 32 == 0) {
+      arrive(barrier_ptr);
+    }
+  }
+
+  wait(barrier_ptr, 1);
+
+  // step3: load biased scores to global memory
+  if (tid < num_load_threads) {
+    ld_shared_st_global<kBytesPerAccess>(output + offset,
+                                         sptr_uint(biased_scores_s + offset));
+  }
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  printf("Starting program...\n");
+  using DType = bfloat16;
+  static constexpr int kN = 256;
+
+  thrust::host_vector<DType> h_a(kN);
+  thrust::host_vector<DType> h_b(kN);
+  thrust::host_vector<DType> h_c_ref(kN);
+
+  for (int i = 0; i < h_a.size(); ++i) {
+    h_a[i] = rand_bfloat16();
+    h_b[i] = rand_bfloat16();
+    h_c_ref[i] = h_a[i] + h_b[i];
+  }
+  thrust::device_vector<DType> d_a = h_a;
+  thrust::device_vector<DType> d_b = h_b;
+
+  thrust::host_vector<DType> h_c(kN);
+  thrust::fill(h_c.begin(), h_c.end(), static_cast<DType>(0));
+  thrust::device_vector<DType> d_c = h_c;
+  CudaCheck(cudaDeviceSynchronize());
+
+  static constexpr int num_sms = 128;
+  static constexpr int kThreads = 512;
+
+  dim3 blocks(num_sms, 1);
+  dim3 threads(kThreads, 1, 1);
+
+  static constexpr int kSharedMemSize =
+      kN * sizeof(DType) * 3 + sizeof(std::uint64_t) /*mbarrier*/;
+
+  test_bar_sync<kN><<<blocks, threads, kSharedMemSize>>>(
+      thrust::raw_pointer_cast(d_a.data()),
+      thrust::raw_pointer_cast(d_b.data()),
+      thrust::raw_pointer_cast(d_c.data()));
+  CudaCheck(cudaDeviceSynchronize());
+
+  cudaError_t error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    printf("CUDA error: %s\n", cudaGetErrorString(error));
+    return -1;
+  }
+
+  printf("Kernel execution completed successfully\n");
+
+  h_c = d_c;
+  for (int i = 0; i < h_c.size(); ++i) {
+    printf("%.2f, ", ToFloat(h_c[i]));
+
+    if ((i + 1) % 8 == 0) printf("\n");
+  }
+
+  printf("\n\nh_c_ref: \n");
+  for (int i = 0; i < h_c.size(); ++i) {
+    printf("%.2f, ", ToFloat(h_c_ref[i]));
+
+    if ((i + 1) % 8 == 0) printf("\n");
+  }
+  printf("\n");
+
+  return 0;
+}

--- a/Cuda/bar_sync/barrier.cuh
+++ b/Cuda/bar_sync/barrier.cuh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace barrier {
+
+__device__ __forceinline__ void init_barrier(std::uint64_t* barrier,
+                                             int arrive_count) {
+  uint32_t barrier_ptr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(barrier));
+  asm volatile(
+      "{\n\t"
+      "mbarrier.init.shared::cta.b64 [%1], %0; \n"
+      "}"
+      :
+      : "r"(arrive_count), "r"(barrier_ptr));
+}
+
+}  // namespace barrier

--- a/Cuda/bar_sync/barrier.cuh
+++ b/Cuda/bar_sync/barrier.cuh
@@ -4,7 +4,7 @@
 
 namespace barrier {
 
-__device__ __forceinline__ void init_barrier(std::uint64_t* barrier,
+__device__ __forceinline__ void init_barrier(uint64_t* barrier,
                                              int arrive_count) {
   uint32_t barrier_ptr =
       static_cast<uint32_t>(__cvta_generic_to_shared(barrier));

--- a/Cuda/bar_sync/copy.cuh
+++ b/Cuda/bar_sync/copy.cuh
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace copy {
+
+template <const int kBytes>
+__device__ __forceinline__ void ld_global_st_shared(uint32_t dst,
+                                                    void const* src) {
+  static_assert(kBytes == 4 || kBytes == 8 || kBytes == 16);
+
+#if (__CUDA_ARCH__ >= 800)
+  // SM90, hopper, SM80, SM86, ampere
+  // TODO(ying): add a wrapper to allow choosing between different caching
+  // policies (e.g. "cache all levels").
+  asm volatile("cp.async.cg.shared.global [%0], [%1], %2;\n" ::"r"(dst),
+               "l"(src), "n"(kBytes));
+#else
+  unsigned tmp[kBytes / 4];
+  if constexpr (kBytes == 16) {
+    asm volatile("ld.global.v4.b32 {%0, %1, %2, %3}, [%4];\n"
+                 : "=r"(tmp[0]), "=r"(tmp[1]), "=r"(tmp[2]), "=r"(tmp[3])
+                 : "l"(src));
+    asm volatile("st.shared.v4.b32 [%0], {%1, %2, %3, %4};\n" ::"r"(dst),
+                 "r"(tmp[0]), "r"(tmp[1]), "r"(tmp[2]), "r"(tmp[3]));
+  } else if constexpr (kBytes == 8) {
+    asm volatile("ld.global.v2.b32 {%0, %1}, [%2];\n"
+                 : "=r"(tmp[0]), "=r"(tmp[1])
+                 : "l"(src));
+    asm volatile("st.shared.v2.b32 [%0], {%1, %2};\n" ::"r"(dst), "r"(tmp[0]),
+                 "r"(tmp[1]));
+  } else if constexpr (kBytes == 4) {
+    asm volatile("ld.global.b32 %0, [%1];\n" : "=r"(tmp[0]) : "l"(src));
+    asm volatile("st.shared.b32 [%0], %1;\n" ::"r"(dst), "r"(tmp[0]));
+  }
+#endif
+}
+
+/// ld.shared
+template <const int kBytes>
+__device__ __forceinline__ void ld_shared(void* dst, uint32_t src);
+
+/// ld.shared - 16b
+template <>
+__device__ __forceinline__ void ld_shared<2>(void* dst, uint32_t src) {
+  asm volatile("ld.shared.u16 %0, [%1];\n"
+               : "=h"(*reinterpret_cast<uint16_t*>(dst))
+               : "r"(src));
+}
+
+/// ld.shared - 32b
+template <>
+__device__ __forceinline__ void ld_shared<4>(void* dst, uint32_t src) {
+  asm volatile("ld.shared.u32 %0, [%1];\n"
+               : "=r"(*reinterpret_cast<uint32_t*>(dst))
+               : "r"(src));
+}
+
+/// ld.shared - 64b
+template <>
+__device__ __forceinline__ void ld_shared<8>(void* dst, uint32_t src) {
+  uint2* dst_u64 = reinterpret_cast<uint2*>(dst);
+  asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];\n"
+               : "=r"(dst_u64->x), "=r"(dst_u64->y)
+               : "r"(src));
+}
+
+/// ld.shared - 128b
+template <>
+__device__ __forceinline__ void ld_shared<16>(void* dst, uint32_t src) {
+  uint4* dst_u128 = reinterpret_cast<uint4*>(dst);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];\n"
+               : "=r"(dst_u128->x), "=r"(dst_u128->y), "=r"(dst_u128->z),
+                 "=r"(dst_u128->w)
+               : "r"(src));
+}
+
+/// st.shared
+template <int kBytes>
+__device__ __forceinline__ void st_shared(uint32_t dst, void const* src);
+
+/// st.shared - 16b
+template <>
+__device__ __forceinline__ void st_shared<2>(uint32_t dst, void const* src) {
+  asm volatile("st.shared.u16 [%0], %1;\n"
+               :
+               : "r"(dst), "h"(*reinterpret_cast<uint16_t const*>(src)));
+}
+
+/// st.shared - 32b
+template <>
+__device__ __forceinline__ void st_shared<4>(uint32_t dst, void const* src) {
+  asm volatile("st.shared.u32 [%0], %1;\n"
+               :
+               : "r"(dst), "r"(*reinterpret_cast<uint32_t const*>(src)));
+}
+
+/// st.shared - 64b
+template <>
+__device__ __forceinline__ void st_shared<8>(uint32_t dst, void const* src) {
+  uint2 const* dst_u64 = reinterpret_cast<uint2 const*>(src);
+  asm volatile("st.shared.v2.u32 [%0], {%1, %2};\n"
+               :
+               : "r"(dst), "r"(dst_u64->x), "r"(dst_u64->y));
+}
+
+/// st.shared - 128b
+template <>
+__device__ __forceinline__ void st_shared<16>(uint32_t dst, void const* src) {
+  uint4 const* dst_u128 = reinterpret_cast<uint4 const*>(src);
+  asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};\n"
+               :
+               : "r"(dst), "r"(dst_u128->x), "r"(dst_u128->y), "r"(dst_u128->z),
+                 "r"(dst_u128->w));
+}
+
+/// st.global
+template <int kBytes>
+__device__ __forceinline__ void st_global(void* dst, const void* src);
+
+template <>
+__device__ __forceinline__ void st_global<16>(void* dst, const void* src) {
+  uint4 const* dst_u128 = reinterpret_cast<uint4 const*>(src);
+  asm volatile("st.global.v4.b32 [%0], {%1, %2, %3, %4};\n"
+               :
+               : "l"(dst), "r"(dst_u128->x), "r"(dst_u128->y), "r"(dst_u128->z),
+                 "r"(dst_u128->w));
+}
+
+template <int kBytes>
+__device__ __forceinline__ void ld_shared_st_global(void* dst, uint32_t src);
+
+template <>
+__device__ __forceinline__ void ld_shared_st_global<16>(void* dst,
+                                                        uint32_t src) {
+  unsigned tmp[4];
+  ld_shared<16>(tmp, src);
+  st_global<16>(dst, tmp);
+}
+}  // namespace copy

--- a/Cuda/bar_sync/run.sh
+++ b/Cuda/bar_sync/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TARGET="bar_sync"
+
+cd build
+
+if [ -f "CMakeCache.txt" ]; then
+    rm -f CMakeCache.txt
+fi
+
+if [ -f $TARGET ]; then
+    rm -f $TARGET
+fi
+
+cmake .. 2>&1 | tee ../build.log
+make $TARGET -j 2>&1 | tee -a ../build.log
+
+if [ -f $TARGET ]; then
+    ./$TARGET 2>&1 | tee ../test.log
+else
+    echo "build $TARGET failed"
+    exit 1
+fi
+
+cd ..

--- a/Cuda/bar_sync/sync.cuh
+++ b/Cuda/bar_sync/sync.cuh
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace block {
+
+__device__ __forceinline__ void sync() { __syncthreads(); }
+
+template <int N>
+__device__ __forceinline__ void wait_group() {
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+
+__device__ __forceinline__ void commit_copy_group() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+__device__ __forceinline__ void copy_async() {
+  commit_copy_group();
+  wait_group<0>();
+}
+
+__device__ __forceinline__ void bar_sync(const unsigned barrier_id,
+                                         const unsigned thread_count) {
+  asm volatile("bar.sync %0, %1;"
+               :
+               : "r"(barrier_id), "r"(thread_count)
+               : "memory");
+}
+
+}  // namespace block

--- a/Cuda/bar_sync/utils.cuh
+++ b/Cuda/bar_sync/utils.cuh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cuda_fp16.h>
+
+typedef __nv_bfloat16 bfloat16;
+typedef __nv_bfloat162 bfloat162;
+
+template <typename T>
+__host__ __device__ float ToFloat(T val);
+
+template <typename T>
+__host__ __device__ T FromFloat(float val);
+
+template <>
+__host__ __device__ float ToFloat(bfloat16 val) {
+  return __bfloat162float(val);
+}
+
+template <>
+__host__ __device__ bfloat16 FromFloat(float val) {
+  return __float2bfloat16(val);
+}

--- a/Cuda/cmake/select_compute_arch.cmake
+++ b/Cuda/cmake/select_compute_arch.cmake
@@ -110,6 +110,34 @@ if(CUDA_VERSION VERSION_GREATER "11.0")
   endif()
 endif()
 
+# Support for newer CUDA architectures (Ada Lovelace, Hopper, etc.)
+if(CUDA_VERSION VERSION_GREATER "11.8")
+  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Ada_Lovelace")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.9")
+  list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.9")
+
+  if(CUDA_VERSION VERSION_LESS "12.0")
+    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.9+PTX")
+  endif()
+endif()
+
+if(CUDA_VERSION VERSION_GREATER "12.0")
+  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Hopper")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "9.0")
+  list(APPEND CUDA_ALL_GPU_ARCHITECTURES "9.0")
+
+  if(CUDA_VERSION VERSION_LESS "12.5")
+    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "9.0+PTX")
+  endif()
+endif()
+
+# Support for compute capability 10.0 (Blackwell architecture)
+if(CUDA_VERSION VERSION_GREATER "12.5")
+  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Blackwell")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "10.0")
+  list(APPEND CUDA_ALL_GPU_ARCHITECTURES "10.0")
+endif()
+
 # ##############################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is
 # enabled) Usage: CUDA_DETECT_INSTALLED_GPUS(OUT_VARIABLE)
@@ -258,6 +286,15 @@ function(CUDA_SELECT_NVCC_ARCH_FLAGS out_variable)
       elseif(${arch_name} STREQUAL "Ampere")
         set(arch_bin 8.0)
         set(arch_ptx 8.0)
+      elseif(${arch_name} STREQUAL "Ada_Lovelace")
+        set(arch_bin 8.9)
+        set(arch_ptx 8.9)
+      elseif(${arch_name} STREQUAL "Hopper")
+        set(arch_bin 9.0)
+        set(arch_ptx 9.0)
+      elseif(${arch_name} STREQUAL "Blackwell")
+        set(arch_bin 10.0)
+        set(arch_ptx 10.0)
       else()
         message(
           SEND_ERROR


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a CUDA barrier-synchronization demo showcasing staged load/compute/store with vectorized ops.
  * Introduced block/barrier sync helpers and efficient shared/global memory copy utilities.
  * Added bfloat16 conversion helpers for host/device use.

* Build
  * New build target with C++/CUDA 17, Release defaults, and stricter warnings.
  * Expanded GPU architecture support (including latest generations) via updated selection logic.

* Chores
  * Improved CUDA toolkit integration and architecture flag handling.

* Scripts
  * New script to build and run the demo, with logs for build and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->